### PR TITLE
Fixed crash in VizbeeCastbarWrapper.js

### DIFF
--- a/src/VizbeeCastBarWrapper.js
+++ b/src/VizbeeCastBarWrapper.js
@@ -34,11 +34,14 @@ const VizbeeCastBarWrapper = ({ height = 64, onVisibilityChange }) => {
       setScreenWidth(width);
     };
 
-    Dimensions.addEventListener("change", handleOrientationChange);
+    const dimensionsSubscription = Dimensions.addEventListener(
+      "change",
+      handleOrientationChange
+    );
 
     // Clean up the event listener on component unmount
     return () => {
-      Dimensions.removeEventListener("change", handleOrientationChange);
+      dimensionsSubscription?.remove();
     };
   }, []);
 


### PR DESCRIPTION
Crash at line  Dimensions.removeEventListener("change", handleOrientationChange) fixed.
