### PR TITLE
Updates to Registering for Listeners(Session, Analytics ...) in iOS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.1.46] - 2025-03-28
 ### Updated
-    Session, Analytics and CastIcon proxy listeners only after initializing the SDK for iOS
+    Updated Session, Analytics, and CastIcon proxy listeners to be registered only after SDK initialization for iOS.
 
 ## [1.1.45] - 2025-03-19
 ### Updated

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Security
 
+## [1.1.46] - 2025-03-28
+### Updated
+    Session, Analytics and CastIcon proxy listeners only after initializing the SDK for iOS
+
 ## [1.1.45] - 2025-03-19
 ### Updated
     Android SDK has been updated to 6.8.5, which includes support for Edge-to-Edge.

--- a/ios/VizbeeBootstrap.m
+++ b/ios/VizbeeBootstrap.m
@@ -6,6 +6,8 @@
 #import "VizbeeBootstrap.h"
 #import "VizbeeAppAdapter.h"
 
+#import <React/RCTLog.h>
+
 @implementation VizbeeBootstrap
 
 +(instancetype) getInstance {
@@ -35,6 +37,11 @@
     
     VizbeeAppAdapter* vizbeeAppAdapter = [[VizbeeAppAdapter alloc] init];
     [Vizbee startWithAppID:vizbeeAppId appAdapterDelegate:vizbeeAppAdapter andVizbeeOptions:options];
+
+    // Post notification that SDK is initialized
+    RCTLogInfo(@"[RNVZBSDK] VizbeeSDKInitialized");
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"VizbeeSDKInitialized" object:nil];
+    
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vizbee-sender-sdk",
-  "version": "1.1.46-rc.1",
+  "version": "1.1.46",
   "description": "React Native SDK for Vizbee Sender. Note: <VizbeeCastBar> component is not supported in React Native's new architecture.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vizbee-sender-sdk",
-  "version": "1.1.45",
+  "version": "1.1.46-rc.1",
   "description": "React Native SDK for Vizbee Sender. Note: <VizbeeCastBar> component is not supported in React Native's new architecture.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Problem:** 
The NFL app not receiving Session and Analytics events

**Cause:** 
The NFL app has been updated to initialize the Vizbee SDK only after feature flags are fetched. However, the RN Continuity wrapper SDK registers session and analytics listeners by observing the app lifecycle (didBecomeActive). Since this is triggered before the SDK is initialized, the registration fails because SessionManager and AnalyticsManager are not available before SDK initialization.

**Solution:**
Moved adding listeners for session and analytics from the app lifecycle to after SDK initialization, as they won’t be available before the SDK is initialized.
 