### PR TITLE
React Native updated to support v0.80.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Security
 
+## [1.1.50] - 2025-07-09
+### Updated
+    Android SDK has been updated to 6.9.1, which includes 16kb page support.
+    Updated React Native peerDependencies upper range to 0.80.1.
+
 ## [1.1.49] - 2025-05-26
 ### Updated
     SmartPlay API with the SmartPlayOptions

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'tv.vizbee:android-sender-sdk:6.9.0'
+    implementation 'tv.vizbee:android-sender-sdk:6.9.1'
 }
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vizbee-sender-sdk",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "description": "React Native SDK for Vizbee Sender. Note: <VizbeeCastBar> component is not supported in React Native's new architecture.",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "Vizbee",
   "license": "ISC",
   "peerDependencies": {
-    "react-native": ">=0.60.0 <=0.76.5"
+    "react-native": ">=0.60.0 <=0.80.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Android SDK has been updated to 6.9.1, which includes 16kb page support and React Native peerDependencies upper range has been updated to 0.80.1.